### PR TITLE
Fix NIALROOT being ignored

### DIFF
--- a/BuildNial/pkgblder/nialcoredefs.ndf
+++ b/BuildNial/pkgblder/nialcoredefs.ndf
@@ -229,8 +229,10 @@ makefilepath IS OP Items {
 
 # set Nialroot to this default MAJ: need to figure out problem
 
-Nialroot := makefilepath OS_Home_Directory 'QNial7' 'Nialroot';
-
+Nialroot := getenv 'NIALROOT';
+IF empty Nialroot THEN
+  Nialroot := link [ OS_Home_Directory, OS_Path_Separator, 'QNial7' ];
+ENDIF;
 
 # operation to create file paths
 


### PR DESCRIPTION
The `NIALROOT` environment variable was being ignored, `Nialroot` always pointing at `$HOME/QNial7`.

The `NIALROOT` environment variable is now recognized, kept in the `Nialroot` varaible, and used to search for libraries.